### PR TITLE
Update scenic and button spacing

### DIFF
--- a/lib/components.ex
+++ b/lib/components.ex
@@ -28,6 +28,8 @@ defmodule Scenic.Keypad.Components do
     add_to_graph(graph, Keypad, nil, options)
   end
 
+  def keypad_spec(options), do: &keypad(&1, options)
+
   defp add_to_graph(%Graph{} = g, mod, data, options) do
     mod.verify!(data)
     mod.add_to_graph(g, data, options)

--- a/lib/keypad.ex
+++ b/lib/keypad.ex
@@ -20,33 +20,32 @@ defmodule Scenic.Keypad do
         fn g ->
           %{
             "1" => [id: 1, t: {0, 0}],
-            "2" => [id: 2, t: {90, 0}],
-            "3" => [id: 3, t: {180, 0}],
+            "2" => [id: 2, t: {50, 0}],
+            "3" => [id: 3, t: {100, 0}],
             "4" => [id: 4, t: {0, 40}],
-            "5" => [id: 5, t: {90, 40}],
-            "6" => [id: 6, t: {180, 40}],
+            "5" => [id: 5, t: {50, 40}],
+            "6" => [id: 6, t: {100, 40}],
             "7" => [id: 7, t: {0, 80}],
-            "8" => [id: 8, t: {90, 80}],
-            "9" => [id: 9, t: {180, 80}],
-            "*" => [id: :asterisk, t: {0, 120}],
-            "0" => [id: 0, t: {90, 120}],
-            "#" => [id: :pound, t: {180, 120}]
+            "8" => [id: 8, t: {50, 80}],
+            "9" => [id: 9, t: {100, 80}],
+            "*" => [id: :asterisk, t: {0, 120}, width: 41],
+            "0" => [id: 0, t: {50, 120}],
+            "#" => [id: :pound, t: {100, 120}]
           }
           |> Enum.reduce(g, fn
             {name, key_options}, graph ->
-              options = Keyword.merge(button_opts, key_options) |> IO.inspect()
+              options = Keyword.merge(button_opts, key_options)
               button(graph, name, options)
           end)
         end,
         opts
       )
-      |> push_graph()
 
-    {:ok, graph}
+    {:ok, graph, push: graph}
   end
 
   def filter_event({:click, button}, _, graph) do
     send_event({:keypad, button})
-    {:stop, graph}
+    {:halt, graph}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ScenicKeypad.MixProject do
   use Mix.Project
 
-  @scenic_version "0.7.0"
+  @scenic_version "0.10"
   @github "https://github.com/BinaryNoggin/scenic_keypad"
 
   def project do


### PR DESCRIPTION
Just a few changes:
* update to scenic >= 0.10
* new `keypad_spec/1` function
* Shorten spacing between buttons a bit
* use `push: graph` return instead of `nush_graph/1`

**New spacing**
![keypad_spacing](https://user-images.githubusercontent.com/11321326/74857697-4f603800-5301-11ea-86e1-35b63cc3e390.png)